### PR TITLE
I-7 Support for integers in where clause

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,11 +11,11 @@ var sqlJsonGenerator = function (options) {
         if (typeof data === 'string' && options.escaped) {
             return sqlString.escape(data);
         }
-        else if (typeof data === 'string') {
-            return "'" + data + "'";
+        else if (typeof data !== 'string' && options.integers) {
+            return data;
         }
         else {
-            return data;
+            return "'" + data + "'";  
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var sqlJsonGenerator = function (options) {
             return data;
         }
         else {
-            return "'" + data + "'";  
+            return "'" + data + "'";
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -11,8 +11,11 @@ var sqlJsonGenerator = function (options) {
         if (typeof data === 'string' && options.escaped) {
             return sqlString.escape(data);
         }
-        else {
+        else if (typeof data === 'string') {
             return "'" + data + "'";
+        }
+        else {
+            return data;
         }
     }
 


### PR DESCRIPTION
This PR is with regards to [Issue 7](https://github.com/manu-de-verdun/sql-json-generator/issues/7)

This PR adds an ability for the escaping function to return our data variable untouched if it is not a string AND if an 'integer' option is set to true upon class construction.

This is to support queries for databases (such as PrestoDB) that cannot perform mathematical operations on integers that become wrapped within apostrophes.

