### PR TITLE
Hotfix - Support integer Zero (prestoDB)

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,36 +130,36 @@ var sqlJsonGenerator = function (options) {
 
             var currentTable = (conditions['$table']) ? conditions['$table'] : inheritedTable;
 
-            if (conditions["$gt"]) {
+            if (typeof conditions["$gt"] !== "undefined") {
                 return conditionBuilder(conditions['$field'], currentTable, '>', conditions["$gt"]);
             }
 
-            else if (conditions["$gte"]) {
+            else if (typeof conditions["$gte"] !== "undefined") {
                 return conditionBuilder(conditions['$field'], currentTable, '>=', conditions["$gte"]);
             }
 
-            else if (conditions["$lt"]) {
+            else if (typeof conditions["$lt"] !== "undefined") {
                 return conditionBuilder(conditions['$field'], currentTable, '<', conditions["$lt"]);
             }
 
-            else if (conditions["$lte"]) {
+            else if (typeof conditions["$lte"] !== "undefined") {
                 return conditionBuilder(conditions['$field'], currentTable, '<=', conditions["$lte"]);
             }
 
-            else if (conditions["$eq"]) {
+            else if (typeof conditions["$eq"] !== "undefined") {
                 return conditionBuilder(conditions['$field'], currentTable, '=', conditions["$eq"]);
             }
 
-            else if (conditions["$ne"]) {
+            else if (typeof conditions["$ne"] !== "undefined") {
                 return conditionBuilder(conditions['$field'], currentTable, '<>', conditions["$ne"]);
             }
 
-            else if (conditions["$like"]) {
+            else if (typeof conditions["$like"] !== "undefined") {
                 return conditionBuilder(conditions['$field'], currentTable, 'LIKE', conditions["$like"]);
             }
 
 
-            else if (conditions["$in"]) {
+            else if (typeof conditions["$in"] !== "undefined") {
 
                 if (options.debug) {
                     console.log('      $in'.cyan);

--- a/test/prestodb.js
+++ b/test/prestodb.js
@@ -8,7 +8,7 @@ describe('#prestoDB - SELECT', function () {
     var sqlGenerator = new SQLGenerator({ prestoDB: true });
     var sqlParams;
 
-    it('query #01 - testing integer type is maintained - equals', function () {
+    it('query #01 - testing integer type is maintained - using equals operator', function () {
 
         sqlParams = {
             $from: 'table1',
@@ -23,7 +23,7 @@ describe('#prestoDB - SELECT', function () {
         sqlGenerator.select(sqlParams).should.equal(expectedResult);
     });
 
-    it('query #02 - testing integer type is mainted - greater than equals', function () {
+    it('query #02 - testing integer type is maintained - using greater than equals operator', function () {
 
         sqlParams = {
             $from: 'table1',
@@ -39,7 +39,7 @@ describe('#prestoDB - SELECT', function () {
         sqlGenerator.select(sqlParams).should.equal(expectedResult);
     });
 
-    it('query #03', function () {
+    it('query #03 - testing float type is maintained', function () {
 
         sqlParams = {
             $from: 'table1',
@@ -55,7 +55,7 @@ describe('#prestoDB - SELECT', function () {
         sqlGenerator.select(sqlParams).should.equal(expectedResult);
     });
 
-    it('query #04', function () {
+    it('query #04 - testing string type on input will be interpreted correctly as a string type by the library', function () {
 
         sqlParams = {
             $from: 'table1',
@@ -71,7 +71,7 @@ describe('#prestoDB - SELECT', function () {
         sqlGenerator.select(sqlParams).should.equal(expectedResult);
     });
 
-    it('query #04', function () {
+    it('query #04 - testing limit syntax correctly forms expected sql query for presto', function () {
 
         sqlParams = {
             $from: 'table1',
@@ -104,7 +104,7 @@ describe('#prestoDB - SELECT', function () {
         sqlGenerator.select(sqlParams).should.equal(expectedResult);
     });
 
-    it('query #06 - testing with integer 0 including and clause', function () {
+    it('query #06 - testing with integer 0 including an $and clause', function () {
 
         sqlParams = {
             $from: 'table1',

--- a/test/prestodb.js
+++ b/test/prestodb.js
@@ -8,7 +8,7 @@ describe('#prestoDB - SELECT', function () {
     var sqlGenerator = new SQLGenerator({ prestoDB: true });
     var sqlParams;
 
-    it('query #01', function () {
+    it('query #01 - testing integer type is maintained - equals', function () {
 
         sqlParams = {
             $from: 'table1',
@@ -23,7 +23,7 @@ describe('#prestoDB - SELECT', function () {
         sqlGenerator.select(sqlParams).should.equal(expectedResult);
     });
 
-    it('query #02', function () {
+    it('query #02 - testing integer type is mainted - greater than equals', function () {
 
         sqlParams = {
             $from: 'table1',
@@ -84,6 +84,46 @@ describe('#prestoDB - SELECT', function () {
         };
 
         var expectedResult = 'SELECT table1.field_a FROM table1 LIMIT 10';
+
+        sqlGenerator.select(sqlParams).should.equal(expectedResult);
+    });
+
+    it('query #05 - testing with integer 0', function () {
+
+        sqlParams = {
+            $from: 'table1',
+            $fields: ['field_a'],
+            $where: [{
+                $field: "field_a",
+                $lt: 0
+            }]
+        };
+
+        var expectedResult = 'SELECT table1.field_a FROM table1 WHERE table1.field_a < 0';
+
+        sqlGenerator.select(sqlParams).should.equal(expectedResult);
+    });
+
+    it('query #06 - testing with integer 0 including and clause', function () {
+
+        sqlParams = {
+            $from: 'table1',
+            $fields: ['field_a'],
+            $where: [{
+                $and : [
+                    {
+                        $field: "field_a",
+                        $lt: 0
+                    },
+                    {
+                        $field: "field_b",
+                        $gt: 20160110
+                    }
+                ]
+            }]
+        };
+
+        var expectedResult = 'SELECT table1.field_a FROM table1 WHERE (table1.field_a < 0 AND table1.field_b > 20160110)';
 
         sqlGenerator.select(sqlParams).should.equal(expectedResult);
     });


### PR DESCRIPTION
Pull request to enable an integer value of 0 to be passed as input to a `where` clause when `prestoDB: true`

The fix is with regards to the following portion of code in `index.js` of the library:


```js
// Line 133 of index.js ...
/** 
 * When the below value is equal to integer 0, this will assert false.
 * Modifying this to check if the value is not undefined will suffice
 */
if (conditions["$gt"]) { 
   return conditionBuilder(conditions['$field'], currentTable, '>', conditions["$gt"]);
}

// ... changing to

if (typeof conditions["$gt"] !== "undefined") {
// ...

```
New unit tests in `test/prestodb.js` have been added. 

All tests are passing after this PR code modifications.

See commits for modifications. Please comment or advise if other implementation is preferred.

As always, thank you! Kind Regards,
Marty